### PR TITLE
Tenant Wide Properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,14 @@ Version|Published
 1.0.0 | May 27, 2021 
 
 
+
 [Supported Clouds](https://github.com/microsoft/mwe-teams-spo-nav/wiki/Supported-Clouds)|[Documentation](https://github.com/microsoft/mwe-teams-spo-nav/wiki)|[Deployment Guide](https://github.com/microsoft/mwe-teams-spo-nav/wiki/Deployment-Guide)|[Release Notes](https://github.com/microsoft/mwe-teams-spo-nav/wiki/Release-Notes)
 -|-|-|-
+
+Commercial|GCC|GCC High|GCC DoD
+-|-|-|-
+![Supported](assets/supported.png)|![Supported](assets/supported.png)|![Unknown](assets/unknown-supported.png)|![Unknown](assets/unknown-supported.png)
+
 
 Adding a modern SharePoint site to Microsoft Teams as an app enables users to access all their site content without having to leave Teams. Example scenarios include:
 * Add your Corporate intranet to Teams for easy discovery of news and content.
@@ -36,14 +42,6 @@ The **mwx-nav** url parameter can be used to hide the navigation in Teams or sho
 
 Now all your SharePoint sites in Teams will have Navigation!
 
-## Supported Clouds
-
-Version|Supported
--|-
-Commercial|![Supported](assets/supported.png)
-GCC|![Supported](assets/supported.png)
-GCC High|![Unknown](assets/unknown-supported.png)
-GCC DoD|![Unknown](assets/unknown-supported.png)
 
 ## Feedback
 

--- a/src/config/package-solution.json
+++ b/src/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "MWX Teams SPO Navigation",
     "id": "c40b89d1-d05f-4623-b02e-b78276a050d2",
-    "version": "1.0.0.6",
+    "version": "1.0.0.7",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false,

--- a/src/sharepoint/assets/ClientSideInstance.xml
+++ b/src/sharepoint/assets/ClientSideInstance.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Elements xmlns="http://schemas.microsoft.com/sharepoint/">
     <ClientSideComponentInstance
-        Title="NavigationPanel"
+        Title="mwx-teams-spo-nav"
         Location="ClientSideExtension.ApplicationCustomizer"
         ComponentId="2982509b-3fff-49f8-8c42-6d4404bc346c"
-        Properties="{&quot;testMessage&quot;:&quot;Test message&quot;}">
+        Properties="{&quot;display&quot;:&quot;&quot;}">
     </ClientSideComponentInstance>
 </Elements>

--- a/src/sharepoint/assets/elements.xml
+++ b/src/sharepoint/assets/elements.xml
@@ -4,6 +4,6 @@
         Title="NavigationPanel"
         Location="ClientSideExtension.ApplicationCustomizer"
         ClientSideComponentId="2982509b-3fff-49f8-8c42-6d4404bc346c"
-        ClientSideComponentProperties="{&quot;testMessage&quot;:&quot;Test message&quot;}">
+        ClientSideComponentProperties="{&quot;display&quot;:&quot;&quot;}">
     </CustomAction>
 </Elements>


### PR DESCRIPTION
Removed the sample tenant wide properties and added a display one we will use in a later release.